### PR TITLE
Give Compose build logic a stable name

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -10,4 +10,6 @@ dependencyResolutionManagement {
     }
 }
 
+rootProject.name = "build-logic"
+
 include(":publishing")


### PR DESCRIPTION
# Give Compose build logic a stable name

Status: kept

Before, Compose Sushi's included `build-logic` build had no explicit root name. Gradle warned that moving the checkout changes generated project-accessor code and the build-script classpath, which breaks cache reuse across workspace paths.

Change: set `rootProject.name = "build-logic"`.

Verification:

- Combined `./gradlew projects` passed.
- Included build remains `:compose-sushi:build-logic`.
- The previous missing-root-name warning is absent.
- `git diff --check` passed.

Branch: `kunal/name-compose-build-logic`
